### PR TITLE
Add tracking code for post author, post id.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "autoload": {
       "psr-4": {
-        "": "src/"
+        "Tarosky\\GoogleAnalyticsReports": "src/"
       }
     },
     "require-dev": {

--- a/functions.php
+++ b/functions.php
@@ -30,7 +30,7 @@ function gar_version() {
  * @return \WP_Error|\Google_Service_AnalyticsReporting_GetReportsResponse
  */
 function gar_reports( $args = [] ) {
-	$reports = GoogleAnalyticsReports\Analytics::get_instance()->get_report( $args );
+	$reports = Tarosky\GoogleAnalyticsReports\Analytics::get_instance()->get_report( $args );
 
 	return $reports;
 }
@@ -89,3 +89,5 @@ function gar_url_to_post( $url ) {
 
 	return get_post( $post_id );
 }
+
+

--- a/google-analytics-reports.php
+++ b/google-analytics-reports.php
@@ -14,4 +14,4 @@
 
 require_once( dirname( __FILE__ ) . '/vendor/autoload.php' );
 
-GoogleAnalyticsReports::get_instance()->register();
+Tarosky\GoogleAnalyticsReports::get_instance()->register();

--- a/src/Tarosky/GoogleAnalyticsReports.php
+++ b/src/Tarosky/GoogleAnalyticsReports.php
@@ -1,4 +1,6 @@
 <?php
+namespace Tarosky;
+
 
 class GoogleAnalyticsReports {
 	private $prefix = 'GoogleAnalyticsReports';
@@ -18,7 +20,7 @@ class GoogleAnalyticsReports {
 	public function register() {
 		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
 
-		require_once( dirname( dirname( __FILE__ ) ) . '/functions.php' );
+		require_once( dirname( dirname( dirname( __FILE__ ) ) ) . '/functions.php' );
 	}
 
 	public function plugins_loaded() {

--- a/src/Tarosky/GoogleAnalyticsReports.php
+++ b/src/Tarosky/GoogleAnalyticsReports.php
@@ -2,6 +2,8 @@
 namespace Tarosky;
 
 
+use Tarosky\GoogleAnalyticsReports\Tracker;
+
 class GoogleAnalyticsReports {
 	private $prefix = 'GoogleAnalyticsReports';
 
@@ -28,6 +30,7 @@ class GoogleAnalyticsReports {
 		if ( is_admin() ) {
 			GoogleAnalyticsReports\Admin::get_instance()->register();
 		}
+		Tracker::get_instance();
 	}
 
 	public function get_prefix() {

--- a/src/Tarosky/GoogleAnalyticsReports/Pattern/Singleton.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Pattern/Singleton.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tarosky\GoogleAnalyticsReports\Pattern;
+
+
+use Tarosky\GoogleAnalyticsReports;
+
+/**
+ * Singleton pattern.
+ *
+ * @package google-analytics-reports
+ * @property-read GoogleAnalyticsReports $google_analytics_reports
+ * @property-read array                  $options
+ * @property-read string                 $prefix
+ */
+abstract class Singleton {
+
+	private static $instances = [];
+
+	/**
+	 * Get instance
+	 *
+	 * @return static
+	 */
+	public static function get_instance() {
+		$class_name = get_called_class();
+		if ( ! isset( self::$instances[ $class_name ] ) ) {
+			self::$instances[ $class_name ] = new $class_name();
+		}
+		return self::$instances[ $class_name ];
+	}
+
+
+	/**
+	 * This class uses empty.
+	 *
+	 * @param string $name
+	 * @return bool
+	 */
+	public function __isset( $name ) {
+		switch ( $name ) {
+			case 'prefix';
+			case 'options':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Getter
+	 *
+	 * @param string $name
+	 * @return mixed
+	 */
+	public function __get( $name ) {
+		switch ( $name ) {
+			case 'google_analytics_reports':
+				return GoogleAnalyticsReports::get_instance();
+			case 'prefix':
+				return $this->google_analytics_reports->get_prefix();
+			case 'options':
+				return get_option( $this->prefix, [] );
+			default:
+				return null;
+		}
+	}
+}

--- a/src/Tarosky/GoogleAnalyticsReports/Tracker.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Tracker.php
@@ -29,7 +29,6 @@ class Tracker extends Singleton {
 			'author'  => is_singular() ? get_queried_object()->post_author : null,
 		] as $key => $value ) {
 			$index = get_option( "google-analytics-reports-{$key}" );
-			var_dump( $index, $value, $key );
 			if ( ! $index || is_null( $value ) ) {
 				continue;
 			}

--- a/src/Tarosky/GoogleAnalyticsReports/Tracker.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Tracker.php
@@ -1,14 +1,56 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tarosky-01
- * Date: 2019-03-11
- * Time: 19:01
- */
 
 namespace Tarosky\GoogleAnalyticsReports;
 
 
-class Tracker {
+use Tarosky\GoogleAnalyticsReports\Pattern\Singleton;
+
+/**
+ * Tracker class
+ *
+ * @package google-analytics-reports
+ */
+class Tracker extends Singleton {
+
+	/**
+	 * Tracker constructor.
+	 */
+	protected function __construct() {
+		add_filter( 'woocommerce_ga_snippet_create', [ $this, 'woocommerce_ga_snippet' ] );
+	}
+
+	/**
+	 * Get extra tags.
+	 */
+	public function get_extra_tags() {
+		$codes = [];
+		foreach ( [
+			'post_id' => is_singular() ? get_queried_object_id() : null,
+			'author'  => is_singular() ? get_queried_object()->post_author : null,
+		] as $key => $value ) {
+			$index = get_option( "google-analytics-reports-{$key}" );
+			var_dump( $index, $value, $key );
+			if ( ! $index || is_null( $value ) ) {
+				continue;
+			}
+			$codes[] = sprintf( "ga('set', 'dimension%d', '%s');", $index, esc_js( $value ) );
+		}
+		$codes = apply_filters( 'google_analytics_reports_code_array', $codes );
+		return implode( "\n", $codes );
+	}
+
+	/**
+	 * Add tracking code to WGI.
+	 *
+	 * @param string $snippet
+	 * @return string
+	 */
+	public function woocommerce_ga_snippet( $snippet ) {
+		$codes = $this->get_extra_tags();
+		if ( $codes ) {
+			$snippet .= $codes;
+		}
+		return $snippet;
+	}
 
 }

--- a/src/Tarosky/GoogleAnalyticsReports/Tracker.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Tracker.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tarosky-01
+ * Date: 2019-03-11
+ * Time: 19:01
+ */
+
+namespace Tarosky\GoogleAnalyticsReports;
+
+
+class Tracker {
+
+}


### PR DESCRIPTION
- Do refactoring
- Change namespace.
- Add new settings for custom definition.

If you enable [WooCommerce Google Analytics Integration](https://ja.wordpress.org/plugins/woocommerce-google-analytics-integration/), codes abover will be displayed.

```js
ga('set', 'dimension1', 3); // Means set custom dimention slot 1 as 3.
```