### PR TITLE
Feature/get author ranking

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,6 +75,48 @@ function gar_report_posts( $args = [] ) {
 }
 
 /**
+ * Get author ranking.
+ *
+ * ## Example
+ *
+ * foreach ( gar_author_pv_ranking() as list( $user_id, $pv ) {
+ *     // Do stuff.
+ * }
+ *
+ * @param $args
+ * @return array|WP_Error array of [ $user_id, $pv ]
+ */
+function gar_author_pv_ranking( $args = [] ) {
+	$dimension_index = get_option( 'google-analytics-reports-author' );
+	if ( ! $dimension_index ) {
+		return new WP_Error( 'not_set', __( 'This site does not collect author score.', 'google-analytics-reports' ), [
+			'status' => 500,
+		] );
+	}
+	$args = wp_parse_args( $args, [
+		'dimensions'    => sprintf( 'ga:dimension%d', $dimension_index ),
+		'metrics'       => 'ga:pageviews',
+		'sortFieldName' => 'ga:pageviews',
+	] );
+	$args = apply_filters( 'google_analytics_reporters_author_pv_ranking', $args );
+	$response = gar_reports( $args );
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+	$results = [];
+	foreach ( $response[0]->getData()->getRows() as $row ) {
+		$dimensions = $row->dimensions;
+		foreach ( $row->metrics as $metric ) {
+			foreach ( $metric->values as $value ) {
+				$dimensions[] = (int) $value;
+			}
+		}
+		$results[] = $dimensions;
+	}
+	return $results;
+}
+
+/**
  * Get post from URL
  *
  * @since 1.0.0

--- a/src/Tarosky/GoogleAnalyticsReports/Tracker.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Tracker.php
@@ -29,6 +29,7 @@ class Tracker extends Singleton {
 			'author'  => is_singular() ? get_queried_object()->post_author : null,
 		] as $key => $value ) {
 			$index = get_option( "google-analytics-reports-{$key}" );
+			$value = apply_filters( 'google_analytics_reporters_dimension_value', $value, $key );
 			if ( ! $index || is_null( $value ) ) {
 				continue;
 			}


### PR DESCRIPTION
Add page views ranking by author.

```php
$result = gar_author_pv_ranking();
if ( is_wp_error( $result ) ) {
   // Error! 
   return;
}
foreach ( $result as list( $user_id, $pv ) ) {
    $user = get_userdata( $user_id );
    printf( '%sさんが%sPVでした！', $user->display_name, number_format( $pv ) );
}
```

And a filter hook is also available for tracking.
If you want metrics to be grouped not by post_author, but by post_paren or taxonomy:

```
add_filter( 'google_analytics_reporters_dimension_value', function( $value, $key ) {
    if ( is_singular() && 'author' === $key ) {
         // For example, author is parent post.
        $value = get_queried_object()->post_parent;
    }
    return $value;
}, 10, 2 );
```