### PR TITLE
Add UUID if Cookie Tasting is enabled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ node_modules/
 *.zip
 /vendor/
 package-lock.json
-
+readme.txt
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ script:
 after_success:
   - sed -i -e "s/nightly/${TRAVIS_TAG}/" $(basename $TRAVIS_REPO_SLUG).php
   - curl https://raw.githubusercontent.com/miya0001/auto-build/master/auto-build.sh | bash
+  - curl -L https://raw.githubusercontent.com/fumikito/wp-readme/master/wp-readme.php | php
+  - sed -i -e "s/Stable tag: nightly/Stable tag: ${TRAVIS_TAG}/" readme.txt
 deploy:
   provider: releases
   skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Google Analytics Reports
 
+<!-- only:github/ -->
 [![Build Status](https://travis-ci.org/tarosky/google-analytics-reports.svg?branch=master)](https://travis-ci.org/tarosky/google-analytics-reports)
+<!-- /only:github -->
 
-Contributors: ko31,tarosky
-Tags:
-Requires at least: 4.5
-Tested up to: 5.1
-Requires PHP: 5.6
-Stable tag: 1.0.0
-License: GPLv2 or later
+Contributors: ko31,tarosky  
+Tags:  
+Requires at least: 4.5  
+Tested up to: 5.1  
+Requires PHP: 5.6  
+Stable tag: nightly  
+License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 This is Google Analytics Reports.

--- a/src/Tarosky/GoogleAnalyticsReports.php
+++ b/src/Tarosky/GoogleAnalyticsReports.php
@@ -3,6 +3,7 @@ namespace Tarosky;
 
 
 use Tarosky\GoogleAnalyticsReports\Tracker;
+use Tarosky\GoogleAnalyticsReports\Uuid;
 
 class GoogleAnalyticsReports {
 	private $prefix = 'GoogleAnalyticsReports';
@@ -35,6 +36,7 @@ class GoogleAnalyticsReports {
 			GoogleAnalyticsReports\Admin::get_instance()->register();
 		}
 		Tracker::get_instance();
+		Uuid::get_instance();
 	}
 
 	public function get_prefix() {

--- a/src/Tarosky/GoogleAnalyticsReports/Admin.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Admin.php
@@ -78,24 +78,26 @@ final class Admin extends Singleton {
 				esc_html__( 'These section will be used for tracking code.', 'google-analytics-reports' )
 			);
 		}, $this->prefix );
-		foreach ( [
-					  'tracking_id' => __( 'Tracking ID', 'google-analytics-reports' ),
-					  'author'      => _x( 'Custom Dimension / Author', 'dimension-name', 'google-analytics-reports' ),
-					  'post_id'     => _x( 'Custom Dimension / Post ID', 'dimension-name', 'google-analytics-reports' ),
-					  'type'        => _x( 'Custom Dimension / Post type', 'dimension-name', 'google-analytics-reports' ),
-				  ] as $key => $label ) {
+		$options = apply_filters( 'google_analytics_reports_options', [
+			'tracking_id' => __( 'Tracking ID', 'google-analytics-reports' ),
+			'author'      => _x( 'Custom Dimension / Author', 'dimension-name', 'google-analytics-reports' ),
+			'post_id'     => _x( 'Custom Dimension / Post ID', 'dimension-name', 'google-analytics-reports' ),
+			'type'        => _x( 'Custom Dimension / Post type', 'dimension-name', 'google-analytics-reports' ),
+		] );
+		foreach ( $options as $key => $label ) {
 			$option_key = "google-analytics-reports-{$key}";
 			add_settings_field( $option_key, $label, function() use ( $option_key, $section_name, $label, $key ) {
 				switch( $key ) {
 					case 'tracking_id':
-						$desc = esc_html__( 'If you want to display tracking code, enter tracking ID. If you enable WooCommerce Google Analytics Integration, you don\'t have to fill.', 'google-analytics-reports' );
+						$desc = __( 'If you want to display tracking code, enter tracking ID. If you enable WooCommerce Google Analytics Integration, you don\'t have to fill.', 'google-analytics-reports' );
 						$placeholder = 'e.g. UA-xxxxxxxx-1';
 						$type = 'text';
 						break;
 					default:
 						// translators: %s is dimension name.
-						$desc = esc_html( sprintf( __( 'To combine %s to every single page views, enter custom dimension index.', 'google-analytics-reports' ), $label ) );
-						$placeholder = '';
+						$desc = sprintf( __( 'To combine %s to every single page views, enter custom dimension index.', 'google-analytics-reports' ), $label );
+						$desc = apply_filters( 'google_analytics_reports_option_desc', $desc, $key );
+						$placeholder = apply_filters( 'google_analytics_reports_option_placeholder', '', $key );
 						$type = 'number';
 						break;
 				}
@@ -104,7 +106,7 @@ final class Admin extends Singleton {
 					esc_attr( $option_key ),
 					esc_attr( get_option( $option_key ) ),
 					$type,
-					$desc,
+					esc_html( $desc ),
 					esc_attr( $placeholder )
 				);
 			}, $this->prefix,  $section_name );

--- a/src/Tarosky/GoogleAnalyticsReports/Tracker.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Tracker.php
@@ -26,7 +26,7 @@ class Tracker extends Singleton {
 	 */
 	protected function __construct() {
 		add_filter( 'woocommerce_ga_snippet_create', [ $this, 'woocommerce_ga_snippet' ] );
-		add_action( 'wp_head', [ $this, 'render_tracking_code' ], 1 );
+		add_action( 'wp_head', [ $this, 'render_tracking_code' ], 100 );
 	}
 
 	/**

--- a/src/Tarosky/GoogleAnalyticsReports/Uuid.php
+++ b/src/Tarosky/GoogleAnalyticsReports/Uuid.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tarosky\GoogleAnalyticsReports;
+
+
+use Tarosky\GoogleAnalyticsReports\Pattern\Singleton;
+
+/**
+ * Handle UUID for Google Analytics.
+ *
+ * @package google-analytics-reports
+ */
+class Uuid extends Singleton {
+	
+	/**
+	 * Uuid constructor
+	 */
+	protected function __construct() {
+		// Check if cookie tasting exist.
+		if ( ! function_exists( 'cookie_tasting_version' ) ) {
+			return;
+		}
+		// Register option.
+		add_filter( 'google_analytics_reports_options', [ $this, 'option_filter' ] );
+		// Change description.
+		add_filter( 'google_analytics_reports_option_desc', [ $this, 'option_desc' ], 10, 2 );
+		// Add extra tags.
+		add_filter( 'google_analytics_reports_code_array', [ $this, 'add_tracking_code' ] );
+	}
+	
+	/**
+	 * Add option.
+	 *
+	 * @param array $options
+	 * @return array
+	 */
+	public function option_filter( $options ) {
+		$options[ 'user_id' ] = __( 'User ID Tracking', 'google-analytics-reports' );
+		return $options;
+	}
+	
+	/**
+	 *
+	 *
+	 * @param string $desc
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function option_desc( $desc, $key ) {
+		if ( 'user_id' === $key ) {
+			$desc = __( 'Set custom dimension index of user scope. An unique id will be set to every user and also set to User ID View.', 'google-analytics-reports' );
+		}
+		return $desc;
+	}
+	
+	/**
+	 * Add tracking code.
+	 *
+	 * @param array $codes
+	 * @return array
+	 */
+	public function add_tracking_code( $codes ) {
+		if ( $index = get_option( 'google-analytics-reports-user_id' ) ) {
+			$js = <<<'JS'
+				!function(){
+  					if ( ! window.CookieTasting ) {
+  					  return;
+  					}
+  					var uuid = CookieTasting.get( 'uuid' );
+  					if ( ! uuid ) {
+  					  return;
+  					}
+  					ga( 'set', 'dimension%d', uuid );
+  					ga( 'set', 'userId', uuid );
+				}();
+JS;
+			$js = sprintf( $js, $index );
+			$codes = array_merge( [ implode( ' ', array_map( 'trim', explode( "\n", $js ) ) ) ], $codes );
+		}
+		return $codes;
+	}
+}


### PR DESCRIPTION
If plugin [Cookie Tasting](https://ja.wordpress.org/plugins/cookie-tasting/) is enabled...

- Add custom dimension index for the user ID in the admin screen.
- Set UUID in the cookie to the specified index.
- [User ID View](https://developers.google.com/analytics/devguides/collection/analyticsjs/user-id) is also set.

## Breaking Change

The priority of analytics code renderer in action hook `wp_head` is moved up to 100 from 1.
It's because of Cookie Tasting compatibility.
1 was too early.