### PR TITLE
Remove use statement before autoloader inclusion.

### DIFF
--- a/google-analytics-reports.php
+++ b/google-analytics-reports.php
@@ -12,8 +12,6 @@
  * @package         GoogleAnalyticsReports
  */
 
-use Miya\WP\GH_Auto_Updater;
-
 require_once( dirname( __FILE__ ) . '/vendor/autoload.php' );
 
 add_action( 'init', 'google_analytics_reports_activate_autoupdate' );
@@ -23,7 +21,7 @@ function google_analytics_reports_activate_autoupdate() {
 	$gh_user = 'tarosky';                      // The user name of GitHub.
 	$gh_repo = 'google-analytics-reports';       // The repository name of your plugin.
 	// Activate automatic update.
-	new GH_Auto_Updater( $plugin_slug, $gh_user, $gh_repo );
+	new Miya\WP\GH_Auto_Updater( $plugin_slug, $gh_user, $gh_repo );
 }
 
 Tarosky\GoogleAnalyticsReports::get_instance()->register();

--- a/tests/test-display.php
+++ b/tests/test-display.php
@@ -5,7 +5,7 @@
  * @package BogoDate
  */
 
-class BogoDate_Display_Test extends WP_UnitTestCase
+class Date_Display_Test extends WP_UnitTestCase
 {
     public function test_get_the_date()
     {


### PR DESCRIPTION
`use` statement is put just before `require dirname( __FILE__ ) . '/vendor/autoload.php'`
Remove it and use absolute namespace.

Travis log:

```
PHP Fatal error:  Uncaught Error: Class 'GH_Auto_Updater' not found in /home/travis/build/tarosky/google-analytics-reports/google-analytics-reports.php:24
```